### PR TITLE
Improve make and docker build output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,13 @@ COPY k3s.fc k3s.if k3s-selinux.spec k3s.sh k3s.te /
 COPY scripts scripts
 RUN scripts/build-setup
 
-ARG TAG=v0+dev-docker
+ARG TAG
 ENV TAG $TAG
+
+ARG COMMIT
+ENV COMMIT $COMMIT
 
 RUN scripts/build
 
 FROM scratch
-COPY --from=build /dist/rpm/noarch/k3s-selinux-*.rpm ./
+COPY --from=build dist /

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,8 @@
+COMMIT ?= $(shell git rev-parse HEAD)
+
 build:
-	docker build -o ./dist .
+	DOCKER_BUILDKIT=1 \
+	docker build \
+		--build-arg TAG=${TAG} \
+		--build-arg COMMIT=${COMMIT} \
+		-o ./dist .


### PR DESCRIPTION
Enable docker buildkit and output files to same /dist directory
that happens during build.

Enable passing a TAG or COMMIT build value.