### PR TITLE
Fix: Add recursive SELinux context for containerd snapshot contents

### DIFF
--- a/policy/centos10/k3s.fc
+++ b/policy/centos10/k3s.fc
@@ -9,7 +9,7 @@
 /var/lib/rancher/k3s(/.*)?                                          gen_context(system_u:object_r:container_var_lib_t,s0)
 /var/lib/rancher/k3s/agent/containerd/[^/]*/snapshots           -d  gen_context(system_u:object_r:container_file_t,s0)
 /var/lib/rancher/k3s/agent/containerd/[^/]*/snapshots/[^/]*     -d  gen_context(system_u:object_r:container_file_t,s0)
-/var/lib/rancher/k3s/agent/containerd/[^/]*/snapshots/[^/]*/.*      <<none>>
+/var/lib/rancher/k3s/agent/containerd/.*/snapshots(/.*)?            gen_context(system_u:object_r:container_file_t,s0)
 /var/lib/rancher/k3s/agent/containerd/[^/]*/sandboxes(/.*)?         gen_context(system_u:object_r:container_share_t,s0)
 /var/lib/rancher/k3s/data(/.*)?                                     gen_context(system_u:object_r:k3s_data_t,s0)
 /var/lib/rancher/k3s/data/.lock                                 --  gen_context(system_u:object_r:k3s_lock_t,s0)

--- a/policy/centos8/k3s.fc
+++ b/policy/centos8/k3s.fc
@@ -9,7 +9,7 @@
 /var/lib/rancher/k3s(/.*)?                                          gen_context(system_u:object_r:container_var_lib_t,s0)
 /var/lib/rancher/k3s/agent/containerd/[^/]*/snapshots           -d  gen_context(system_u:object_r:container_file_t,s0)
 /var/lib/rancher/k3s/agent/containerd/[^/]*/snapshots/[^/]*     -d  gen_context(system_u:object_r:container_file_t,s0)
-/var/lib/rancher/k3s/agent/containerd/[^/]*/snapshots/[^/]*/.*      <<none>>
+/var/lib/rancher/k3s/agent/containerd/.*/snapshots(/.*)?            gen_context(system_u:object_r:container_file_t,s0)
 /var/lib/rancher/k3s/agent/containerd/[^/]*/sandboxes(/.*)?         gen_context(system_u:object_r:container_share_t,s0)
 /var/lib/rancher/k3s/data(/.*)?                                     gen_context(system_u:object_r:k3s_data_t,s0)
 /var/lib/rancher/k3s/data/.lock                                 --  gen_context(system_u:object_r:k3s_lock_t,s0)

--- a/policy/centos9/k3s.fc
+++ b/policy/centos9/k3s.fc
@@ -9,7 +9,7 @@
 /var/lib/rancher/k3s(/.*)?                                          gen_context(system_u:object_r:container_var_lib_t,s0)
 /var/lib/rancher/k3s/agent/containerd/[^/]*/snapshots           -d  gen_context(system_u:object_r:container_file_t,s0)
 /var/lib/rancher/k3s/agent/containerd/[^/]*/snapshots/[^/]*     -d  gen_context(system_u:object_r:container_file_t,s0)
-/var/lib/rancher/k3s/agent/containerd/[^/]*/snapshots/[^/]*/.*      <<none>>
+/var/lib/rancher/k3s/agent/containerd/.*/snapshots(/.*)?            gen_context(system_u:object_r:container_file_t,s0)
 /var/lib/rancher/k3s/agent/containerd/[^/]*/sandboxes(/.*)?         gen_context(system_u:object_r:container_share_t,s0)
 /var/lib/rancher/k3s/data(/.*)?                                     gen_context(system_u:object_r:k3s_data_t,s0)
 /var/lib/rancher/k3s/data/.lock                                 --  gen_context(system_u:object_r:k3s_lock_t,s0)

--- a/policy/coreos/k3s.fc
+++ b/policy/coreos/k3s.fc
@@ -9,7 +9,7 @@
 /var/lib/rancher/k3s(/.*)?                                          gen_context(system_u:object_r:container_var_lib_t,s0)
 /var/lib/rancher/k3s/agent/containerd/[^/]*/snapshots           -d  gen_context(system_u:object_r:container_file_t,s0)
 /var/lib/rancher/k3s/agent/containerd/[^/]*/snapshots/[^/]*     -d  gen_context(system_u:object_r:container_file_t,s0)
-/var/lib/rancher/k3s/agent/containerd/[^/]*/snapshots/[^/]*/.*      <<none>>
+/var/lib/rancher/k3s/agent/containerd/.*/snapshots(/.*)?            gen_context(system_u:object_r:container_file_t,s0)
 /var/lib/rancher/k3s/agent/containerd/[^/]*/sandboxes(/.*)?         gen_context(system_u:object_r:container_share_t,s0)
 /var/lib/rancher/k3s/data(/.*)?                                     gen_context(system_u:object_r:k3s_data_t,s0)
 /var/lib/rancher/k3s/data/.lock                                 --  gen_context(system_u:object_r:k3s_lock_t,s0)

--- a/policy/microos/k3s.fc
+++ b/policy/microos/k3s.fc
@@ -9,7 +9,7 @@
 /var/lib/rancher/k3s(/.*)?                                          gen_context(system_u:object_r:container_var_lib_t,s0)
 /var/lib/rancher/k3s/agent/containerd/[^/]*/snapshots           -d  gen_context(system_u:object_r:container_file_t,s0)
 /var/lib/rancher/k3s/agent/containerd/[^/]*/snapshots/[^/]*     -d  gen_context(system_u:object_r:container_file_t,s0)
-/var/lib/rancher/k3s/agent/containerd/[^/]*/snapshots/[^/]*/.*      <<none>>
+/var/lib/rancher/k3s/agent/containerd/.*/snapshots(/.*)?            gen_context(system_u:object_r:container_file_t,s0)
 /var/lib/rancher/k3s/agent/containerd/[^/]*/sandboxes(/.*)?         gen_context(system_u:object_r:container_share_t,s0)
 /var/lib/rancher/k3s/data(/.*)?                                     gen_context(system_u:object_r:k3s_data_t,s0)
 /var/lib/rancher/k3s/data/.lock                                 --  gen_context(system_u:object_r:k3s_lock_t,s0)

--- a/policy/slemicro/k3s.fc
+++ b/policy/slemicro/k3s.fc
@@ -9,7 +9,7 @@
 /var/lib/rancher/k3s(/.*)?                                          gen_context(system_u:object_r:container_var_lib_t,s0)
 /var/lib/rancher/k3s/agent/containerd/[^/]*/snapshots           -d  gen_context(system_u:object_r:container_share_t,s0)
 /var/lib/rancher/k3s/agent/containerd/[^/]*/snapshots/[^/]*     -d  gen_context(system_u:object_r:container_share_t,s0)
-/var/lib/rancher/k3s/agent/containerd/[^/]*/snapshots/[^/]*/.*      <<none>>
+/var/lib/rancher/k3s/agent/containerd/.*/snapshots(/.*)?            gen_context(system_u:object_r:container_file_t,s0)
 /var/lib/rancher/k3s/agent/containerd/[^/]*/sandboxes(/.*)?         gen_context(system_u:object_r:container_share_t,s0)
 /var/lib/rancher/k3s/data(/.*)?                                     gen_context(system_u:object_r:k3s_data_t,s0)
 /var/lib/rancher/k3s/data/.lock                                 --  gen_context(system_u:object_r:k3s_lock_t,s0)


### PR DESCRIPTION
Issue: #72 
This PR updates the SELinux file context policy for K3s to correctly label the contents inside containerd snapshot directories.

